### PR TITLE
Adding wof:placetype_alt values to wof:hierarchy

### DIFF
--- a/mapzen/whosonfirst/export/__init__.py
+++ b/mapzen/whosonfirst/export/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import types
 import time
 import sys
@@ -178,7 +179,7 @@ class flatfile:
 
         if props.has_key('wof:placetype_alt'):
             for a in props['wof:placetype_alt']:
-                k = "%s_id" % props['wof:placetype_alt']
+                k = "%s_id" % a
                 v = props['wof:id']
                 
                 if not h.get(k, False) or h[k] == -1:

--- a/mapzen/whosonfirst/export/__init__.py
+++ b/mapzen/whosonfirst/export/__init__.py
@@ -168,12 +168,21 @@ class flatfile:
         # ensure hierarchy contains self
 
         for h in props['wof:hierarchy']:
-
             k = "%s_id" % props['wof:placetype']
             v = props['wof:id']
 
             if not h.get(k, False) or h[k] == -1:
                 h[k] = int(v)
+
+        # ensure hierarchy contains placetype_alt(s)
+
+        if props.has_key('wof:placetype_alt'):
+            for a in props['wof:placetype_alt']:
+                k = "%s_id" % props['wof:placetype_alt']
+                v = props['wof:id']
+                
+                if not h.get(k, False) or h[k] == -1:
+                    h[k] = int(v)
 
         # ensure belongs to
 


### PR DESCRIPTION
Fixes #12.

Updated the export code to add each value in the `wof:placetype_alt` property to a record's `wof:hierarchy`. This change was tested locally using a [`borough` in Buenos Aires](https://whosonfirst.mapzen.com/spelunker/id/1109371849/).

original properties:

```
    "wof:belongsto":[
        102191577,
        421174285,
        85632505,
        85668081
    ],
...
    "wof:hierarchy":[
        {
            "borough_id":1109371849,
            "continent_id":102191577,
            "country_id":85632505,
            "locality_id":421174285,
            "region_id":85668081
        }
    ],
    "wof:id":1109371849,
...
    "wof:placetype":"borough",
    "wof:placetype_alt":[
        "county"
    ],
```

exporting results in:

```
    "wof:belongsto":[
        85668081,
        102191577,
        85632505,
        421174285
    ],
...
    "wof:hierarchy":[
        {
            "borough_id":1109371849,
            "continent_id":102191577,
            "country_id":85632505,
            "county_id":1109371849,   <--
            "locality_id":421174285,
            "region_id":85668081
        }
    ],
    "wof:id":1109371849,
...
    "wof:placetype":"borough",
    "wof:placetype_alt":[
        "county"
    ],
```

`# -*- coding: utf-8 -*-` was added to line 1 due to this error when testing:
```
 Traceback (most recent call last):
  File "../Desktop/test_hier_build.py", line 6, in <module>
    import export
  File "../py-mapzen-whosonfirst-export/mapzen/whosonfirst/export/__init__.py", line 273
SyntaxError: Non-ASCII character '\xe2' in file /../py-mapzen-whosonfirst-export/mapzen/whosonfirst/export/__init__.py on line 273, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```