### PR TITLE
Update wof:repo logic

### DIFF
--- a/mapzen/whosonfirst/export/__init__.py
+++ b/mapzen/whosonfirst/export/__init__.py
@@ -145,10 +145,10 @@ class flatfile:
         # ensure 'wof:repo'
         # https://github.com/whosonfirst/whosonfirst-data/issues/338
 
-        if props.get('wof:repo', None) == None:
+        data_root = self.root
+        repo_root = os.path.dirname(data_root)
 
-            data_root = self.root
-            repo_root = os.path.dirname(data_root)
+        if not props['wof:repo'] == os.path.basename(repo_root):
             props['wof:repo'] = os.path.basename(repo_root)
 
         # ensure edtf stuff - it might be time for py-whosonfirst-dates/edtf package

--- a/mapzen/whosonfirst/export/__init__.py
+++ b/mapzen/whosonfirst/export/__init__.py
@@ -148,6 +148,9 @@ class flatfile:
         data_root = self.root
         repo_root = os.path.dirname(data_root)
 
+        if props.get('wof:repo', None) == None:
+            props['wof:repo'] = os.path.basename(repo_root)
+
         if not props['wof:repo'] == os.path.basename(repo_root):
             props['wof:repo'] = os.path.basename(repo_root)
 


### PR DESCRIPTION
This change updates the way the `wof:repo` property is updated.

Right now, `wof:repo` is only written if the property does not exist. If the `wof:repo` property exists, the property value is not updated.

This change compares the `wof:repo` property value with the current repo root, which is needed when moving records between per-country repositories (like what is needed to fix [this issue](https://github.com/whosonfirst-data/whosonfirst-data/issues/1460)).

This may be a specific use case, but could be useful nonetheless.