### PR TITLE
remove deprecated --process-dependency-links flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ guide (specifically that GeoJSON properties but _not_ geometries be indented).
 ## Install
 
 ```
-sudo pip install -r requirements.txt --process-dependency-links .
+sudo pip install -r requirements.txt .
 ```
 
 ### Caveats


### PR DESCRIPTION
since [pip 19.0](https://pip.pypa.io/en/stable/news/#v19-0) (2019-01-22) the `--process-dependency-links` flag is no longer supported.

resolves https://github.com/whosonfirst/py-mapzen-whosonfirst-export/issues/20